### PR TITLE
Three bug fixes

### DIFF
--- a/MLS/tests/tests.xqy
+++ b/MLS/tests/tests.xqy
@@ -667,6 +667,7 @@ declare variable $tests:unit-tests as element(tests:unit-tests) :=
     <accept-test>
       <request xmlns="http://marklogic.com/appservices/rest">
         <accept>application/xml</accept>
+        <accept>application/json</accept>
         <http method="GET"/>
         <http method="POST"/>
       </request>
@@ -699,6 +700,7 @@ declare variable $tests:unit-tests as element(tests:unit-tests) :=
     <accept-test>
       <request xmlns="http://marklogic.com/appservices/rest">
         <accept>application/xml</accept>
+        <accept>application/json</accept>
         <http method="GET"/>
         <http method="POST"/>
       </request>


### PR DESCRIPTION
SEC-PRIV error is 403 instead of 401.
SEC-PRIV won't override implementation's response codes.

request element with multiple accept blocks added to 'and' blacklist and to test cases.

NOTE test case exercises code that's not used in production anywhere (rest-impl:accept) and does not test the bug or the fix.
